### PR TITLE
Changed stylesheet to style to match correct cytoscape.js syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var sbgnStylesheet = require('cytoscape-sbgn-stylesheet');
 
 var cy = cytoscape({
   container: container,
-  stylesheet: sbgnStylesheet(cytoscape),
+  style: sbgnStylesheet(cytoscape),
   // other arguments here
 });
 


### PR DESCRIPTION
### Issue
As can be seen in this StackOverflow [post](https://stackoverflow.com/questions/66018649/stylesheet-for-cytoscape-does-not-take-affect-text-and-graph-does-not-show-corr), following the usage instructions causes problems where the stylesheet is not applied.

### Cause
The readme contains a usage instruction on how to initialize cytoscape.js with the sbgn-stylesheet. Currently, the key `stylesheet` is stated for initializing stylesheets, cytoscape.js uses just `style` though.

The documentation states this about the stylesheet option: 
- style : The stylesheet used to style the graph. For convenience, this option can alternatively be specified as a promise that resolves to the stylesheet.

### Changes

Just the readme passage